### PR TITLE
refactor: long types and wchar_t cross-platform compatibility

### DIFF
--- a/src/as/arch/riscv64/asm_code.c
+++ b/src/as/arch/riscv64/asm_code.c
@@ -24,11 +24,11 @@ void make_code32(Inst *inst, Code *code, unsigned int *buf, int len) {
 }
 
 inline bool is_im6(int64_t x) {
-  return x <= ((1L << 5) - 1) && x >= -(1L << 5);
+  return x <= ((1LL << 5) - 1) && x >= -(1LL << 5);
 }
 
 inline bool is_im12(int64_t x) {
-  return x <= ((1L << 11) - 1) && x >= -(1L << 11);
+  return x <= ((1LL << 11) - 1) && x >= -(1LL << 11);
 }
 
 inline bool assemble_error(const ParseInfo *info, const char *message) {

--- a/src/as/arch/x64/asm_code.c
+++ b/src/as/arch/x64/asm_code.c
@@ -135,7 +135,7 @@ static unsigned char *asm_mov_imr(Inst *inst, Code *code) {
 
 static unsigned char *asm_mov_ir(Inst *inst, Code *code) {
   if (inst->src.indirect.offset->kind == EX_FIXNUM) {
-    long offset = inst->src.indirect.offset->fixnum;
+    long long offset = inst->src.indirect.offset->fixnum;
     enum RegSize size = inst->dst.reg.size;
     if (inst->src.indirect.reg.no != RIP) {
       int sno = opr_regno(&inst->src.indirect.reg);
@@ -167,7 +167,7 @@ static unsigned char *asm_mov_ir(Inst *inst, Code *code) {
 
 static unsigned char *asm_mov_ri(Inst *inst, Code *code) {
   if (inst->dst.indirect.offset->kind == EX_FIXNUM) {
-    long offset = inst->dst.indirect.offset->fixnum;
+    long long offset = inst->dst.indirect.offset->fixnum;
     enum RegSize size = inst->src.reg.size;
     if (inst->dst.indirect.reg.no != RIP) {
       int sno = opr_regno(&inst->src.reg);
@@ -199,7 +199,7 @@ static unsigned char *asm_mov_ri(Inst *inst, Code *code) {
 
 static unsigned char *asm_mov_iir(Inst *inst, Code *code) {
   if (inst->src.indirect_with_index.offset->kind == EX_FIXNUM) {
-    long offset = inst->src.indirect_with_index.offset->fixnum;
+    long long offset = inst->src.indirect_with_index.offset->fixnum;
     assert(is_im32(offset));
     short offset_bit = offset == 0 ? 0x04 : is_im8(offset) ? 0x44 : 0x84;
     enum RegSize size = inst->dst.reg.size;
@@ -288,7 +288,7 @@ static unsigned char *asm_mov_sr(Inst *inst, Code *code) {
 }
 
 static unsigned char *asm_movbwlq_imi(Inst *inst, Code *code) {
-  long offset = inst->dst.indirect.offset->fixnum;
+  long long offset = inst->dst.indirect.offset->fixnum;
   unsigned char sno = 0;
   unsigned char dno = opr_regno(&inst->dst.indirect.reg);
   unsigned char op = (offset == 0 && (dno & 7) != RBP - RAX) ? 0x00 : is_im8(offset) ? (unsigned char)0x40 : (unsigned char)0x80;
@@ -311,7 +311,7 @@ static unsigned char *asm_movbwlq_imi(Inst *inst, Code *code) {
     p += 4;
   }
 
-  long value = inst->src.immediate;
+  long long value = inst->src.immediate;
   switch (inst->op) {
   case MOVB: *p++ = IM8(value); break;
   case MOVW: PUT_CODE(p, IM16(value)); p += 2; break;
@@ -341,7 +341,7 @@ static unsigned char *asm_movbwlq_imd(Inst *inst, Code *code) {
   PUT_CODE(p, IM32(dst));
   p += 4;
 
-  long value = inst->src.immediate;
+  long long value = inst->src.immediate;
   switch (inst->op) {
   case MOVB: *p++ = IM8(value); break;
   case MOVW: PUT_CODE(p, IM16(value)); p += 2; break;
@@ -441,7 +441,7 @@ static unsigned char *asm_movsd_xx(Inst *inst, Code *code) { return asm_movsds_x
 static unsigned char *asm_movss_xx(Inst *inst, Code *code) { return asm_movsds_xx(inst, code, true); }
 
 static unsigned char *asm_movsds_ix(Inst *inst, Code *code, bool single) {
-  long offset;
+  long long offset;
   if (inst->src.indirect.offset->kind == EX_FIXNUM &&
       (offset = inst->src.indirect.offset->fixnum, is_im32(offset))) {
     if (inst->src.indirect.reg.no != RIP) {
@@ -482,7 +482,7 @@ static unsigned char *asm_movsd_ix(Inst *inst, Code *code) { return asm_movsds_i
 static unsigned char *asm_movss_ix(Inst *inst, Code *code) { return asm_movsds_ix(inst, code, true); }
 
 static unsigned char *asm_movsds_xi(Inst *inst, Code *code, bool single) {
-  long offset;
+  long long offset;
   if (inst->dst.indirect.offset->kind == EX_FIXNUM &&
       (offset = inst->dst.indirect.offset->fixnum, is_im32(offset))) {
     if (inst->dst.indirect.reg.no != RIP) {
@@ -661,7 +661,7 @@ static unsigned char *asm_sqrtsd_xx(Inst *inst, Code *code) {
   return p;
 }
 
-static long signed_immediate(long value, enum RegSize size) {
+static long long signed_immediate(long long value, enum RegSize size) {
   switch (size) {
   case REG8:   return (int8_t)value;
   case REG16:  return (int16_t)value;
@@ -677,7 +677,7 @@ static unsigned char *asm_lea_ir(Inst *inst, Code *code) {
   unsigned char *p = code->buf;
   if (inst->src.indirect.reg.no != RIP) {
     if (inst->src.indirect.offset->kind == EX_FIXNUM) {
-      long offset = inst->src.indirect.offset->fixnum;
+      long long offset = inst->src.indirect.offset->fixnum;
       enum RegSize size = inst->dst.reg.size;
       short buf[] = {
         MAKE_REX_INDIRECT(
@@ -706,8 +706,8 @@ static unsigned char *asm_lea_iir(Inst *inst, Code *code) {
   Expr *scale_expr = inst->src.indirect_with_index.scale;
   if ((offset_expr == NULL || offset_expr->kind == EX_FIXNUM) &&
       (scale_expr == NULL || scale_expr->kind == EX_FIXNUM)) {
-    long offset = offset_expr != NULL ? offset_expr->fixnum : 0;
-    long scale = scale_expr != NULL ? scale_expr->fixnum : 1;
+    long long offset = offset_expr != NULL ? offset_expr->fixnum : 0;
+    long long scale = scale_expr != NULL ? scale_expr->fixnum : 1;
     if (is_im32(offset) && 1 <= scale && scale <= 8 && IS_POWER_OF_2(scale)) {
       int breg = opr_regno(&inst->src.indirect_with_index.base_reg);
       int ireg = opr_regno(&inst->src.indirect_with_index.index_reg);
@@ -746,7 +746,7 @@ static unsigned char *asm_add_rr(Inst *inst, Code *code) {
 }
 
 static unsigned char *asm_add_imr(Inst *inst, Code *code) {
-  long value = inst->src.immediate;
+  long long value = inst->src.immediate;
   if (is_im32(value)) {
     bool im8 = is_im8(value);
     enum RegSize size = inst->dst.reg.size;
@@ -777,7 +777,7 @@ static unsigned char *asm_add_imr(Inst *inst, Code *code) {
 
 static unsigned char *asm_add_ir(Inst *inst, Code *code) {
   if (inst->src.indirect.offset->kind == EX_FIXNUM && inst->src.indirect.reg.no != RIP) {
-    long offset = inst->src.indirect.offset->fixnum;
+    long long offset = inst->src.indirect.offset->fixnum;
     enum RegSize size = inst->dst.reg.size;
     unsigned char *p = code->buf;
     short buf[] = {
@@ -820,9 +820,9 @@ static unsigned char *asm_add_iir(Inst *inst, Code *code) {
 
 static unsigned char *asm_addq_imi(Inst *inst, Code *code) {
   if (inst->dst.indirect.offset->kind == EX_FIXNUM) {
-    long value = inst->src.immediate;
+    long long value = inst->src.immediate;
     if (is_im32(value)) {
-      long offset = inst->dst.indirect.offset->fixnum;
+      long long offset = inst->dst.indirect.offset->fixnum;
       unsigned char sno = 0;
       unsigned char dno = opr_regno(&inst->dst.indirect.reg);
       unsigned char op = (offset == 0 && (dno & 7) != RBP - RAX) ? 0x00 : is_im8(offset) ? (unsigned char)0x40 : (unsigned char)0x80;
@@ -864,7 +864,7 @@ static unsigned char *asm_sub_rr(Inst *inst, Code *code) {
 }
 
 static unsigned char *asm_sub_imr(Inst *inst, Code *code) {
-  long value = inst->src.immediate;
+  long long value = inst->src.immediate;
   if (is_im32(value)) {
     bool im8 = is_im8(value);
     enum RegSize size = inst->dst.reg.size;
@@ -895,7 +895,7 @@ static unsigned char *asm_sub_imr(Inst *inst, Code *code) {
 
 static unsigned char *asm_sub_ir(Inst *inst, Code *code) {
   if (inst->src.indirect.offset->kind == EX_FIXNUM && inst->src.indirect.reg.no != RIP) {
-    long offset = inst->src.indirect.offset->fixnum;
+    long long offset = inst->src.indirect.offset->fixnum;
     enum RegSize size = inst->dst.reg.size;
     unsigned char *p = code->buf;
     short buf[] = {
@@ -938,9 +938,9 @@ static unsigned char *asm_sub_iir(Inst *inst, Code *code) {
 
 static unsigned char *asm_subq_imi(Inst *inst, Code *code) {
   if (inst->dst.indirect.offset->kind == EX_FIXNUM) {
-    long value = inst->src.immediate;
+    long long value = inst->src.immediate;
     if (is_im32(value)) {
-      long offset = inst->dst.indirect.offset->fixnum;
+      long long offset = inst->dst.indirect.offset->fixnum;
       unsigned char sno = 0;
       unsigned char dno = opr_regno(&inst->dst.indirect.reg);
       unsigned char op = (offset == 0 && (dno & 7) != RBP - RAX) ? 0x28 : is_im8(offset) ? (unsigned char)0x40 : (unsigned char)0x80;
@@ -1036,7 +1036,7 @@ static unsigned char *asm_inc_r(Inst *inst, Code *code) {
 static unsigned char *asm_incbwlq_i(Inst *inst, Code *code) {
   if (inst->src.indirect.reg.no != RIP) {
     enum RegSize size = inst->op + (REG8 - INCB);
-    long offset = inst->src.indirect.offset->fixnum;
+    long long offset = inst->src.indirect.offset->fixnum;
     unsigned char *p = code->buf;
     short buf[] = {
       MAKE_REX_INDIRECT(
@@ -1061,7 +1061,7 @@ static unsigned char *asm_dec_r(Inst *inst, Code *code) {
 static unsigned char *asm_decbwlq_i(Inst *inst, Code *code) {
   if (inst->src.indirect.reg.no != RIP) {
     enum RegSize size = inst->op + (REG8 - DECB);
-    long offset = inst->src.indirect.offset->fixnum;
+    long long offset = inst->src.indirect.offset->fixnum;
     unsigned char *p = code->buf;
     short buf[] = {
       MAKE_REX_INDIRECT(
@@ -1085,7 +1085,7 @@ static unsigned char *asm_and_rr(Inst *inst, Code *code) {
 }
 
 static unsigned char *asm_and_imr(Inst *inst, Code *code) {
-  long value = inst->src.immediate;
+  long long value = inst->src.immediate;
   enum RegSize size = inst->dst.reg.size;
   unsigned char *p = code->buf;
   if (is_im8(value) && (size != REG8 || opr_regno(&inst->dst.reg) != AL - AL)) {
@@ -1127,7 +1127,7 @@ static unsigned char *asm_or_rr(Inst *inst, Code *code) {
 }
 
 static unsigned char *asm_or_imr(Inst *inst, Code *code) {
-  long value = inst->src.immediate;
+  long long value = inst->src.immediate;
   enum RegSize size = inst->dst.reg.size;
   unsigned char *p = code->buf;
   if (is_im8(value) && (size != REG8 || opr_regno(&inst->dst.reg) != AL - AL)) {
@@ -1168,7 +1168,7 @@ static unsigned char *asm_xor_rr(Inst *inst, Code *code) {
 }
 
 static unsigned char *asm_xor_imr(Inst *inst, Code *code) {
-  long value = inst->src.immediate;
+  long long value = inst->src.immediate;
   enum RegSize size = inst->dst.reg.size;
   unsigned char *p = code->buf;
   if (is_im8(value) && (size != REG8 || opr_regno(&inst->dst.reg) != AL - AL)) {
@@ -1276,7 +1276,7 @@ static unsigned char *asm_cmp_rr(Inst *inst, Code *code) {
 
 static unsigned char *asm_cmp_imr(Inst *inst, Code *code) {
   enum RegSize size = inst->dst.reg.size;
-  long value = signed_immediate(inst->src.immediate, size);
+  long long value = signed_immediate(inst->src.immediate, size);
   if (is_im32(value) || size <= REG32) {
     bool im8 = is_im8(value);
     int d = opr_regno(&inst->dst.reg);
@@ -1352,7 +1352,7 @@ static unsigned char *asm_push_r(Inst *inst, Code *code) {
 
 static unsigned char *asm_push_im(Inst *inst, Code *code) {
   unsigned char *p = code->buf;
-  long value = inst->src.immediate;
+  long long value = inst->src.immediate;
   if (is_im8(value)) {
     *p++ = 0x6a;
     *p++ = IM8(value);
@@ -1396,7 +1396,7 @@ static unsigned char *asm_jmp_der(Inst *inst, Code *code) {
 static unsigned char *asm_jmp_dei(Inst *inst, Code *code) {
   Expr *offset_expr = inst->src.indirect.offset;
   if ((offset_expr == NULL || offset_expr->kind == EX_FIXNUM)) {
-    long offset = offset_expr != NULL ? offset_expr->fixnum : 0;
+    long long offset = offset_expr != NULL ? offset_expr->fixnum : 0;
     if (is_im32(offset)) {
       short offset_bit = offset == 0 ? 0x20 : is_im8(offset) ? 0x60 : 0xa0;
       short b = inst->src.indirect.reg.no;
@@ -1425,8 +1425,8 @@ static unsigned char *asm_jmp_deii(Inst *inst, Code *code) {
   Expr *scale_expr = inst->src.indirect_with_index.scale;
   if ((offset_expr == NULL || offset_expr->kind == EX_FIXNUM) &&
       (scale_expr == NULL || scale_expr->kind == EX_FIXNUM)) {
-    long offset = offset_expr != NULL ? offset_expr->fixnum : 0;
-    long scale = scale_expr != NULL ? scale_expr->fixnum : 1;
+    long long offset = offset_expr != NULL ? offset_expr->fixnum : 0;
+    long long scale = scale_expr != NULL ? scale_expr->fixnum : 1;
     if (is_im32(offset) && 1 <= scale && scale <= 8 && IS_POWER_OF_2(scale)) {
       short b = inst->src.indirect_with_index.base_reg.no;
       short scale_bit = kPow2Table[scale];
@@ -1481,7 +1481,7 @@ static unsigned char *asm_ret(Inst *inst, Code *code) {
 }
 
 static unsigned char *asm_int_im(Inst *inst, Code *code) {
-  long value = inst->src.immediate;
+  long long value = inst->src.immediate;
   MAKE_CODE(inst, code, 0xcd, IM8(value));
   return code->buf;
 }

--- a/src/as/as.c
+++ b/src/as/as.c
@@ -2,7 +2,6 @@
 
 #include <assert.h>
 #include <ctype.h>
-#include <stdint.h>  // uintptr_t
 #include <stdio.h>
 #include <string.h>
 #include <strings.h>  // strncasecmp
@@ -68,7 +67,7 @@ static void drop_all(FILE *fp) {
   }
 }
 
-static void putnum(FILE *fp, unsigned long num, int bytes) {
+static void putnum(FILE *fp, size_t num, int bytes) {
   for (int i = 0; i < bytes; ++i) {
     fputc(num, fp);
     num >>= 8;

--- a/src/as/ir_asm.h
+++ b/src/as/ir_asm.h
@@ -3,7 +3,7 @@
 #pragma once
 
 #include <stddef.h>  // size_t
-#include <stdint.h>  // uintptr_t
+#include <stdint.h>  // uintptr_t, intptr_t
 
 #include "asm_code.h"  // Code
 

--- a/src/cc/arch/aarch64/emit_code.c
+++ b/src/cc/arch/aarch64/emit_code.c
@@ -207,7 +207,7 @@ static void emit_defun(Function *func) {
   size_t frame_size = ALIGN(fnbe->frame_size, 16);
   bool fp_saved = false;  // Frame pointer saved?
   bool lr_saved = false;  // Link register saved?
-  unsigned long used_reg_bits = fnbe->ra->used_reg_bits;
+  uint64_t used_reg_bits = fnbe->ra->used_reg_bits;
   if (!no_stmt) {
     fp_saved = frame_size > 0 || fnbe->ra->flag & RAF_STACK_FRAME;
     lr_saved = (func->flag & FUNCF_HAS_FUNCALL) != 0;
@@ -217,7 +217,7 @@ static void emit_defun(Function *func) {
       STP(FP, LR, PRE_INDEX(SP, -16));
 
       // FP is saved, so omit from callee save.
-      used_reg_bits &= ~(1UL << GET_FPREG_INDEX());
+      used_reg_bits &= ~(1ULL << GET_FPREG_INDEX());
     }
 
     // Callee save.

--- a/src/cc/arch/riscv64/emit_code.c
+++ b/src/cc/arch/riscv64/emit_code.c
@@ -167,7 +167,7 @@ static void emit_defun(Function *func) {
   size_t frame_size = ALIGN(fnbe->frame_size, 16);
   bool fp_saved = false;  // Frame pointer saved?
   bool ra_saved = false;  // Return Address register saved?
-  unsigned long used_reg_bits = fnbe->ra->used_reg_bits;
+  uint64_t used_reg_bits = fnbe->ra->used_reg_bits;
   int vaarg_params_saved = 0;
   if (!no_stmt) {
     if (func->type->func.vaargs) {
@@ -187,7 +187,7 @@ static void emit_defun(Function *func) {
       SD(FP, IMMEDIATE_OFFSET0(SP));
 
       // FP is saved, so omit from callee save.
-      used_reg_bits &= ~(1UL << GET_FPREG_INDEX());
+      used_reg_bits &= ~(1ULL << GET_FPREG_INDEX());
     }
 
     // Callee save.

--- a/src/cc/arch/x64/emit_code.c
+++ b/src/cc/arch/x64/emit_code.c
@@ -19,7 +19,7 @@
 #include "var.h"
 #include "x64.h"
 
-int count_callee_save_regs(unsigned long used, unsigned long fused);
+int count_callee_save_regs(uint64_t used, uint64_t fused);
 
 char *im(int64_t x) {
   return fmt("$%" PRId64, x);

--- a/src/cc/backend/codegen.c
+++ b/src/cc/backend/codegen.c
@@ -708,7 +708,7 @@ void map_virtual_to_physical_registers(RegAlloc *ra) {
 // Detect living registers for each instruction.
 void detect_living_registers(RegAlloc *ra, BBContainer *bbcon) {
   int maxbit = ra->settings->phys_max + ra->settings->fphys_max;
-  unsigned long living_pregs = 0;
+  uint64_t living_pregs = 0;
   assert((int)sizeof(living_pregs) * CHAR_BIT >= maxbit);
   LiveInterval **livings = ALLOCA(sizeof(*livings) * maxbit);
   for (int i = 0; i < maxbit; ++i)
@@ -726,7 +726,7 @@ void detect_living_registers(RegAlloc *ra, BBContainer *bbcon) {
     if (li->state != LI_NORMAL || VREGFOR(li, ra) == NULL)
       continue;
     int bitno = BITNO(li, ra);
-    living_pregs |= 1UL << bitno;
+    living_pregs |= 1ULL << bitno;
     livings[bitno] = li;
   }
 
@@ -739,7 +739,7 @@ void detect_living_registers(RegAlloc *ra, BBContainer *bbcon) {
         LiveInterval *li = livings[k];
         if (li != NULL && nip == li->end) {
           assert(BITNO(li, ra) == k);
-          living_pregs &= ~(1UL << k);
+          living_pregs &= ~(1ULL << k);
           livings[k] = NULL;
         }
       }
@@ -762,7 +762,7 @@ void detect_living_registers(RegAlloc *ra, BBContainer *bbcon) {
         if (nip == li->start) {
           assert(VREGFOR(li, ra) != NULL);
           int bitno = BITNO(li, ra);
-          living_pregs |= 1UL << bitno;
+          living_pregs |= 1ULL << bitno;
           livings[bitno] = li;
         }
       }

--- a/src/cc/backend/codegen_expr.c
+++ b/src/cc/backend/codegen_expr.c
@@ -175,14 +175,14 @@ static VReg *gen_cast(Expr *expr) {
       is_fixnum(dst_type->kind) && dst_type->fixnum.is_unsigned && dst_size >= 8) {
     // Transform from (uint64_t)flonum
     //   to: (flonum <= INT64_MAX) ? (int64_t)flonum
-    //                             : ((int64_t)(flonum - (INT64_MAX + 1UL)) ^ (1L << 63))
+    //                             : ((int64_t)(flonum - (INT64_MAX + 1ULL)) ^ (1LL << 63))
     const Token *token = expr->token;
     Type *i64t = get_fixnum_type_from_size(dst_size);
     Expr *cond = new_expr_bop(EX_LE, &tyBool, token, src,
                               new_expr_flolit(src->type, src->token, INT64_MAX));
     Expr *offsetted = new_expr_addsub(
         EX_SUB, token, src,
-        new_expr_flolit(src->type, src->token, (uint64_t)INT64_MAX + 1UL));
+        new_expr_flolit(src->type, src->token, (uint64_t)INT64_MAX + 1ULL));
     Expr *xorred = new_expr_bop(EX_BITXOR, i64t, token, make_cast(i64t, token, offsetted, false),
                                 new_expr_fixlit(i64t, token, (uint64_t)1 << 63));
     Expr *ternary = new_expr_ternary(token, cond, make_cast(i64t, token, src, false), xorred, i64t);
@@ -206,7 +206,7 @@ static VReg *gen_cast(Expr *expr) {
     if (dst_size < (1 << vreg->vsize) && dst_size < (int)sizeof(Fixnum)) {
       // Assume that integer is represented in Two's complement
       size_t bit = dst_size * TARGET_CHAR_BIT;
-      UFixnum mask = (-1UL) << bit;
+      UFixnum mask = (-1ULL) << bit;
       if (!is_unsigned(dst_type) && (value & (1 << (bit - 1))))    // signed && negative
         value |= mask;
       else

--- a/src/cc/backend/ir.h
+++ b/src/cc/backend/ir.h
@@ -150,7 +150,7 @@ typedef struct IR {
       int arg_count;
       int stack_args_size;
       int stack_aligned;
-      unsigned long living_pregs;
+      uint64_t living_pregs;
       Vector *caller_saves;  // <const char*>
     } precall;
     struct {
@@ -232,8 +232,8 @@ typedef struct BBContainer {
 BBContainer *new_func_blocks(void);
 void detect_from_bbs(BBContainer *bbcon);
 void analyze_reg_flow(BBContainer *bbcon);
-int push_callee_save_regs(unsigned long used, unsigned long fused);
-void pop_callee_save_regs(unsigned long used, unsigned long fused);
+int push_callee_save_regs(uint64_t used, uint64_t fused);
+void pop_callee_save_regs(uint64_t used, uint64_t fused);
 
 void emit_bb_irs(BBContainer *bbcon);
 

--- a/src/cc/backend/regalloc.h
+++ b/src/cc/backend/regalloc.h
@@ -19,7 +19,7 @@ enum LiveIntervalState {
 };
 
 typedef struct LiveInterval {
-  unsigned long occupied_reg_bit;  // Represent occupied registers in bit.
+  uint64_t occupied_reg_bit;  // Represent occupied registers in bit.
   enum LiveIntervalState state;
   int start;
   int end;
@@ -28,7 +28,7 @@ typedef struct LiveInterval {
 } LiveInterval;
 
 typedef struct RegAllocSettings {
-  unsigned long (*detect_extra_occupied)(RegAlloc *ra, IR *ir);
+  uint64_t (*detect_extra_occupied)(RegAlloc *ra, IR *ir);
   const int *reg_param_mapping;
   int phys_max;              // Max physical register count.
   int phys_temporary_count;  // Temporary register count (= start index for saved registers)
@@ -45,8 +45,8 @@ typedef struct RegAlloc {
   LiveInterval *intervals;  // size=vregs->len
   LiveInterval **sorted_intervals;
 
-  unsigned long used_reg_bits;
-  unsigned long used_freg_bits;
+  uint64_t used_reg_bits;
+  uint64_t used_freg_bits;
   int flag;
 } RegAlloc;
 

--- a/src/cc/builtin.c
+++ b/src/cc/builtin.c
@@ -45,7 +45,7 @@ static Expr *proc_builtin_nan(const Token *ident) {
     parse_error(PE_NOFATAL, fmt->token, "String literal expected");
   }
 
-  const uint64_t MASK = (1UL << 52) - 1UL;
+  const uint64_t MASK = (1ULL << 52) - 1ULL;
   union { double d; uint64_t q; } u;
   u.d = NAN;
   u.q = (u.q & ~MASK) | (significand & MASK);

--- a/src/cc/frontend/fe_misc.c
+++ b/src/cc/frontend/fe_misc.c
@@ -317,7 +317,7 @@ const MemberInfo *search_from_anonymous(const Type *type, const Name *name, cons
     const MemberInfo *member = &sinfo->members[i];
     if (member->name != NULL) {
       if (equal_name(member->name, name)) {
-        vec_push(stack, (void*)(long)i);
+        vec_push(stack, (void*)(long long)i);
         return member;
       }
     } else if (member->type->kind == TY_STRUCT) {

--- a/src/cc/frontend/lexer.c
+++ b/src/cc/frontend/lexer.c
@@ -616,8 +616,8 @@ static void *convert_str_to_wstr(const char *src, size_t *plen) {
       break;
   }
 
-  wchar_t *wstr = malloc_or_die(len * sizeof(*wstr));
-  wchar_t *q = wstr;
+  int *wstr = malloc_or_die(len * sizeof(*wstr));
+  int *q = wstr;
   for (const char *p = src;; ) {
     int c;
     p = read_utf8_char(p, &c);

--- a/src/cc/frontend/lexer.c
+++ b/src/cc/frontend/lexer.c
@@ -510,7 +510,7 @@ static Token *read_num(const char **pp) {
   if (tt == TK_INTLIT) {
     const int INT_BYTES = 4;  // TODO: Detect.
     int bits = INT_BYTES * TARGET_CHAR_BIT;
-    unsigned long long threshold = 1UL << (bits - (is_unsigned ? 0 : 1));
+    unsigned long long threshold = 1ULL << (bits - (is_unsigned ? 0 : 1));
     if (val >= threshold)
       tt = TK_LONGLIT;
   }

--- a/src/cc/frontend/parser_expr.c
+++ b/src/cc/frontend/parser_expr.c
@@ -855,7 +855,7 @@ static Expr *parse_prim(void) {
       {TK_ULONGLIT, FX_LONG, true},
       {TK_ULLONGLIT, FX_LLONG, true},
 #ifndef __NO_WCHAR
-      {TK_WCHARLIT, FX_INT, true},  // TODO: Must match with target's wchar_t
+      {TK_WCHARLIT, FX_INT, true},  // Uses 32-bit wchar_t internally
 #endif
     };
     for (int i = 0; i < (int)ARRAY_SIZE(TABLE); ++i) {

--- a/src/cc/frontend/parser_expr.c
+++ b/src/cc/frontend/parser_expr.c
@@ -145,7 +145,7 @@ static Expr *parse_member_access(Expr *target, Token *acctok) {
     Expr *p = target;
     Token *tok = acctok;
     for (int i = 0; i < stack->len; ++i) {
-      int index = (int)(long)stack->data[i];
+      int index = (int)(long long)stack->data[i];
       const MemberInfo *minfo = &type->struct_.info->members[index];
       type = qualified_type(minfo->type, type->qualifier);
       const Name *member_name = NULL;

--- a/src/cpp/pp_parser.h
+++ b/src/cpp/pp_parser.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <stdint.h>  // intptr_t
 #include <stdio.h>  // FILE
 
 #include "lexer.h"  // TokenKind, Token

--- a/src/ld/ld.c
+++ b/src/ld/ld.c
@@ -276,7 +276,7 @@ static void resolve_rela_elfobj(LinkEditor *ld, ElfObj *elfobj) {
       case R_RISCV_CALL:
         {
           int64_t offset = address - pc;
-          assert(offset < (1L << 19) && offset >= -(1L << 19));  // TODO
+          assert(offset < (1LL << 19) && offset >= -(1LL << 19));  // TODO
           *(uint32_t*)p = W_JAL(RA, offset);
         }
         break;
@@ -299,7 +299,7 @@ static void resolve_rela_elfobj(LinkEditor *ld, ElfObj *elfobj) {
       case R_RISCV_PCREL_HI20:
         {
           int64_t offset = address - pc;
-          assert(offset < (1L << 31) && offset >= -(1L << 31));
+          assert(offset < (1LL << 31) && offset >= -(1LL << 31));
           // const uint32_t MASK20 = (1U << 20) - 1;
           const uint32_t MASK12 = (1U << 12) - 1;
           if ((offset & MASK12) >= (1U << 11))
@@ -319,7 +319,7 @@ static void resolve_rela_elfobj(LinkEditor *ld, ElfObj *elfobj) {
           uintptr_t hipc = elfobj->section_infos[shdr->sh_info].progbits.address + hirela->r_offset;
 
           int64_t offset = hiaddress - hipc;
-          assert(offset < (1L << 31) && offset >= -(1L << 31));
+          assert(offset < (1LL << 31) && offset >= -(1LL << 31));
           const uint32_t MASK20 = (1U << 20) - 1;
           const uint32_t MASK12 = (1U << 12) - 1;
           *(uint32_t*)p = (*(uint32_t*)p & MASK20) | (((uint32_t)offset & MASK12) << 20);
@@ -328,7 +328,7 @@ static void resolve_rela_elfobj(LinkEditor *ld, ElfObj *elfobj) {
       case R_RISCV_RVC_JUMP:
         {
           int64_t offset = address - pc;
-          assert(offset < (1L << 11) && offset >= -(1L << 11));
+          assert(offset < (1LL << 11) && offset >= -(1LL << 11));
 
           uint16_t *q = (uint16_t*)p;
           assert((*q & 0xe003) == 0xa001);  // c.j
@@ -338,7 +338,7 @@ static void resolve_rela_elfobj(LinkEditor *ld, ElfObj *elfobj) {
       case R_RISCV_JAL:
         {
           int64_t offset = address - pc;
-          assert(offset < (1L << 19) && offset >= -(1L << 19));
+          assert(offset < (1LL << 19) && offset >= -(1LL << 19));
 
           uint32_t *q = (uint32_t*)p;
           assert((*q & 0x0000007f) == 0x6f);  // jal
@@ -663,7 +663,7 @@ static void dump_map_elfobj(LinkEditor *ld, ElfObj *elfobj, File *file, ArConten
       break;
     default: assert(false); break;
     }
-    fprintf(fp, "%9lx: %.*s  (%s", address, NAMES(name), file->filename);
+    fprintf(fp, "%9llx: %.*s  (%s", (unsigned long long)address, NAMES(name), file->filename);
     if (content != NULL)
       fprintf(fp, ", %s", content->name);
     fprintf(fp, ")\n");
@@ -770,11 +770,11 @@ int main(int argc, char *argv[]) {
       }
 
       fprintf(mapfp, "### Symbols\n");
-      fprintf(mapfp, "%9lx:  (start address)\n", (long)LOAD_ADDRESS);
+      fprintf(mapfp, "%9llx:  (start address)\n", (unsigned long long)LOAD_ADDRESS);
       dump_map_file(ld, mapfp);
 
       fprintf(mapfp, "\n### Entry point\n");
-      fprintf(mapfp, "%9lx: %.*s\n", entry_address, NAMES(entry_name));
+      fprintf(mapfp, "%9llx: %.*s\n", (unsigned long long)entry_address, NAMES(entry_name));
 
       if (mapfp != stdout)
         fclose(mapfp);

--- a/src/util/gen_section.h
+++ b/src/util/gen_section.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <stddef.h>  // size_t
-#include <stdint.h>  // uintptr_t
 #include <stdio.h>   // FILE
+#include <stdint.h>  // uintptr_t, intptr_t
 
 #define SECTION_COUNT  (4)
 

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -295,15 +295,15 @@ void show_error_line(const char *line, const char *p, int len) {
 }
 
 bool is_im8(intptr_t x) {
-  return x <= ((1L << 7) - 1) && x >= -(1L << 7);
+  return x <= ((1LL << 7) - 1) && x >= -(1LL << 7);
 }
 
 bool is_im16(intptr_t x) {
-  return x <= ((1L << 15) - 1) && x >= -(1L << 15);
+  return x <= ((1LL << 15) - 1) && x >= -(1LL << 15);
 }
 
 bool is_im32(intptr_t x) {
-  return x <= ((1L << 31) - 1) && x >= -(1L << 31);
+  return x <= ((1LL << 31) - 1) && x >= -(1LL << 31);
 }
 
 const char *skip_whitespaces(const char *s) {

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -4,9 +4,11 @@
 
 #include <stdbool.h>
 #include <stddef.h>  // size_t
-#include <stdint.h>  // intptr_t
 #include <stdio.h>  // FILE
 #include <sys/types.h>  // ssize_t
+#include <stdint.h>
+
+#include "../config.h"
 
 #define MIN(a, b)  ((a) < (b) ? (a) : (b))
 #define MAX(a, b)  ((a) > (b) ? (a) : (b))

--- a/src/wcc/gen_wasm.c
+++ b/src/wcc/gen_wasm.c
@@ -1883,7 +1883,7 @@ static Expr *proc_builtin_nan(const Token *ident) {
     parse_error(PE_NOFATAL, fmt->token, "String literal expected");
   }
 
-  const uint64_t MASK = (1UL << 52) - 1UL;
+  const uint64_t MASK = (1ULL << 52) - 1ULL;
   union { double d; uint64_t q; } u;
   u.d = NAN;
   u.q = (u.q & ~MASK) | (significand & MASK);

--- a/src/wcc/traverse.c
+++ b/src/wcc/traverse.c
@@ -4,6 +4,7 @@
 #include <assert.h>
 #include <stdlib.h>  // malloc
 #include <string.h>  // memcpy
+#include <inttypes.h> // PRIx64
 
 #include "ast.h"
 #include "fe_misc.h"  // curscope
@@ -858,7 +859,7 @@ void traverse_ast(Vector *decls) {
         info->non_prim.address = address;
         size_t size = type_size(varinfo->type);
         address += size;
-        VERBOSE("%04x: %.*s  (size=0x%lx)\n", info->non_prim.address, NAMES(varinfo->name), size);
+        VERBOSE("%04x: %.*s  (size=0x%" PRIx64 ")\n", info->non_prim.address, NAMES(varinfo->name), (uint64_t)size);
       }
     }
   }


### PR DESCRIPTION
Requirement for #1.

This seems to be one of the more invasive changes necessary.

1. `unsigned long`, `long`, `uintptr_t` and `intptr_t` do not have sizes that are explicitly defined in the C spec, while some of the arithmetic done on it assumes 64-bit sizes. The pointer types have been replaced with typedefs, and all of these types ultimately resolve to long long or stdint types now.
2. The use of `wchar_t` is now explicitly a 32-bit integer inside the compiler.