### PR TITLE
feat: Win32 compatibility for wcc (MinGW64 MSYS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,18 @@ Compile C to WebAssembly/WASI binary.
   * node.js
   * `llvm-ar`
 
+Install NodeJS dependencies:
+```sh
+npm install
+```
+
+##### MinGW-w64 (Windows)
+
+Install dependencies:
+```sh
+pacman -S llvm mingw64/mingw-w64-x86_64-nodejs
+```
+
 #### Build
 
 ```sh

--- a/src/ar/ar.h
+++ b/src/ar/ar.h
@@ -1,0 +1,66 @@
+/*	$OpenBSD: ar.h,v 1.3 2003/06/02 19:34:12 millert Exp $	*/
+/*	$NetBSD: ar.h,v 1.4 1994/10/26 00:55:43 cgd Exp $	*/
+
+/*-
+ * Copyright (c) 1991, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ * (c) UNIX System Laboratories, Inc.
+ * All or some portions of this file are derived from material licensed
+ * to the University of California by American Telephone and Telegraph
+ * Co. or Unix System Laboratories, Inc. and are reproduced herein with
+ * the permission of UNIX System Laboratories, Inc.
+ *
+ * This code is derived from software contributed to Berkeley by
+ * Hugh Smith at The University of Guelph.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)ar.h	8.2 (Berkeley) 1/21/94
+ */
+
+#ifndef _AR_H_
+#define	_AR_H_
+
+/* Pre-4BSD archives had these magic numbers in them. */
+#define	OARMAG1	0177555
+#define	OARMAG2	0177545
+
+#define	ARMAG		"!<arch>\n"	/* ar "magic number" */
+#define	SARMAG		8		/* strlen(ARMAG); */
+
+#define	AR_EFMT1	"#1/"		/* extended format #1 */
+
+struct ar_hdr {
+	char ar_name[16];		/* name */
+	char ar_date[12];		/* modification time */
+	char ar_uid[6];			/* user id */
+	char ar_gid[6];			/* group id */
+	char ar_mode[8];		/* octal file permissions */
+	char ar_size[10];		/* size in bytes */
+#define	ARFMAG	"`\n"
+	char ar_fmag[2];		/* consistency check */
+};
+
+#endif /* !_AR_H_ */

--- a/src/as/as.c
+++ b/src/as/as.c
@@ -6,7 +6,7 @@
 #include <string.h>
 #include <strings.h>  // strncasecmp
 #include <sys/stat.h>
-#include <unistd.h>
+#include <unistd.h> // isatty
 
 #include "asm_code.h"
 #include "elfutil.h"
@@ -129,7 +129,7 @@ static int output_obj(const char *ofn, Table *label_table, Vector *unresolved) {
         continue;
       }
       sym = symtab_add(symtabs[bind], name);
-      int type;
+      int type = 0;
       switch (info->kind) {
       case LK_NONE:    type = STT_NOTYPE; break;
       case LK_FUNC:    type = STT_FUNC; break;

--- a/src/config.h
+++ b/src/config.h
@@ -1,5 +1,21 @@
 #pragma once
 
+#ifdef _WIN32
+
+// 32-bit or 64-bit
+#if _WIN64
+#define __LP64__
+#else
+#define __ILP32__
+#endif
+
+#else // POSIX
+
+#define USE_ALLOCA
+
+#endif
+
+
 // Architecture
 #define XCC_ARCH_X64      1
 #define XCC_ARCH_AARCH64  2
@@ -44,8 +60,6 @@
 #  define NO_STD_LIB
 # endif
 #endif
-
-#define USE_ALLOCA
 
 #if defined(USE_ALLOCA)
 #include <alloca.h>

--- a/src/cpp/macro.c
+++ b/src/cpp/macro.c
@@ -1,7 +1,6 @@
 #include "../config.h"
 #include "macro.h"
 
-#include <alloca.h>
 #include <assert.h>
 #include <limits.h>  // INT_MAX
 #include <stdlib.h>  // malloc

--- a/src/ld/ld.c
+++ b/src/ld/ld.c
@@ -1,6 +1,6 @@
 #include "../config.h"
 
-#include <ar.h>
+#include "../ar/ar.h"
 #include <assert.h>
 #include <fcntl.h>
 #include <stdbool.h>

--- a/src/util/archive.c
+++ b/src/util/archive.c
@@ -5,7 +5,7 @@
 #include <string.h>
 
 // https://sourceware.org/git/?p=binutils-gdb.git;a=blob;f=include/aout/ar.h;h=471a859fc57c7d8207193718610980f6bf2f83b3;hb=2cb5c79dad39dd438fb0f7372ac04cf5aa2a7db7
-#include <ar.h>
+#include "../ar/ar.h"
 
 #include "util.h"
 

--- a/src/util/elfutil.h
+++ b/src/util/elfutil.h
@@ -5,10 +5,10 @@
 #include <stdint.h>  // ssize_t
 #include <stdio.h>  // FILE
 
-#ifdef __APPLE__
-#include "../../include/elf.h"
-#else
+#if defined(__linux__)
 #include <elf.h>
+#else
+#include "../../include/elf.h"
 #endif
 
 #include "table.h"

--- a/src/util/getline.h
+++ b/src/util/getline.h
@@ -31,7 +31,6 @@
 
 #include <stdlib.h>
 #include <stdio.h>
-#include <unistd.h>
 #include <errno.h>
 #include <string.h>
 

--- a/src/util/getline.h
+++ b/src/util/getline.h
@@ -1,0 +1,85 @@
+/*-
+ * Copyright (c) 2011 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software contributed to The NetBSD Foundation
+ * by Christos Zoulas.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <errno.h>
+#include <string.h>
+
+ssize_t
+getdelim(char **buf, size_t *bufsiz, int delimiter, FILE *fp)
+{
+	char *ptr, *eptr;
+
+
+	if (*buf == NULL || *bufsiz == 0) {
+		*bufsiz = BUFSIZ;
+		if ((*buf = malloc(*bufsiz)) == NULL)
+			return -1;
+	}
+
+	for (ptr = *buf, eptr = *buf + *bufsiz;;) {
+		int c = fgetc(fp);
+		if (c == -1) {
+			if (feof(fp)) {
+				ssize_t diff = (ssize_t)(ptr - *buf);
+				if (diff != 0) {
+					*ptr = '\0';
+					return diff;
+				}
+			}
+			return -1;
+		}
+		*ptr++ = c;
+		if (c == delimiter) {
+			*ptr = '\0';
+			return ptr - *buf;
+		}
+		if (ptr + 2 >= eptr) {
+			char *nbuf;
+			size_t nbufsiz = *bufsiz * 2;
+			ssize_t d = ptr - *buf;
+			if ((nbuf = realloc(*buf, nbufsiz)) == NULL)
+				return -1;
+			*buf = nbuf;
+			*bufsiz = nbufsiz;
+			eptr = nbuf + nbufsiz;
+			ptr = nbuf + d;
+		}
+	}
+}
+
+ssize_t
+getline(char **buf, size_t *bufsiz, FILE *fp)
+{
+	return getdelim(buf, bufsiz, '\n', fp);
+}

--- a/src/util/platform.c
+++ b/src/util/platform.c
@@ -1,0 +1,416 @@
+#include "platform.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+//////////////////////////////////////////////////////////////////////////////
+// Platform independent implementations
+//////////////////////////////////////////////////////////////////////////////
+
+// Modifies a path in-place to changes slashes to forward slashes only,
+// so it doesn't generate escape sequences in the preprocessor include generator
+char* platform_pathslashes(char* buf) {
+  size_t i;
+  for(i = 0; i < strlen(buf); ++i) {
+    if (buf[i] == '\\') {
+      buf[i] = '/';
+    }
+  }
+  return buf;
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// Platform specific implementations
+//////////////////////////////////////////////////////////////////////////////
+//
+// Win32
+//
+#ifdef _WIN32
+
+#include <io.h>
+#include <fcntl.h>
+#include <windows.h>
+#include <shlwapi.h>
+#include <process.h>
+
+char* strndup(const char* s1, unsigned long long n) {
+    char* c = (char*)malloc(n + 1);
+    memcpy(c, s1, n);
+    c[n] = 0;
+    return c;
+}
+
+// Creates a temporary file with a given extension and returns the path
+FILE* platform_mktempfile2(const char* ext, char** path, const char* mode) {
+  if (!path) {
+    return NULL;
+  }
+
+  char tp[MAX_PATH + 1];
+  char* fn = strdup("xcc-XXXXXX");
+
+  // Temporary path
+  if (!GetTempPath(sizeof(tp), tp)) {
+    free(fn);
+    return NULL;
+  }
+  tp[MAX_PATH] = 0;
+
+  // Temporary filename
+  mktemp(fn);
+  if (!fn) {
+    return NULL;
+  }
+
+  // Construct full path
+  char fp[MAX_PATH + 1] = { 0 };
+  snprintf(fp, (sizeof(char) * MAX_PATH), "%s%s%s", tp, fn, ext ? ext : "");
+  fp[MAX_PATH] = 0;
+  free(fn);
+
+  *path = strdup(fp);
+
+  // Open file
+  return fopen(fp, mode);
+}
+
+// Opens a temporary file cached by the filesystem, shouldn't normally cache to disk
+FILE* fmemopen(void* buf, size_t len, const char* mode) {
+  // Uses a temporary file to simulate fmemopen, though FILE_ATTRIBUTE_TEMPORARY should keep it cached in RAM
+  // Only supports 'b' in mode
+
+  int fd;
+  FILE *fp;
+  char tp[MAX_PATH - 32];
+  char fn[MAX_PATH + 1];
+  HANDLE h;
+
+  (void)mode;
+
+  if (!GetTempPath(sizeof(tp), tp)) {
+    return NULL;
+  }
+
+  if (!GetTempFileName(tp, "xcc", 0, fn)) {
+    return NULL;
+  }
+
+  h = CreateFile(fn, GENERIC_READ | GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_TEMPORARY | FILE_FLAG_DELETE_ON_CLOSE, NULL);
+  if (INVALID_HANDLE_VALUE == h) {
+    return NULL;
+  }
+
+  fd = _open_osfhandle((intptr_t)h, _O_APPEND);
+  if (fd < 0) {
+    CloseHandle(h);
+    return NULL;
+  }
+
+  if (strchr(mode, 'b') != NULL) {
+    fp = fdopen(fd, "wb+");
+  } else {
+    fp = fdopen(fd, "w+");
+  }
+  if (!fp) {
+    CloseHandle(h);
+    return NULL;
+  }
+
+  if (buf != NULL && len > 0) {
+    fwrite(buf, len, 1, fp);
+    rewind(fp);
+  }
+
+  return fp;
+}
+
+// Creates a temporary file, opens it in write-binary mode
+FILE* platform_mktempfile(void) {
+  // Opens a temporary file in write and binary mode cached by the filesystem, shouldn't normally cache to disk
+  return fmemopen(NULL, 0, "wb");
+}
+
+FILE* open_memstream(char** data, size_t* len) {
+  // Dummy, actually handled in flush_memstream on this platform, and wrap fmemopen instead
+  (void)data;
+  (void)len;
+  // Opens a temporary file in write and binary mode cached by the filesystem, shouldn't normally cache to disk
+  return platform_mktempfile();
+}
+
+// Flushes the temporary file and ensures the data pointer contains a pointer to the contents of the buffer if necessary
+void flush_memstream(FILE* file, char** data, size_t* len) {
+  if (!file || !data || !len) {
+    return;
+  }
+
+  // Get file length
+  if (fseek(file, 0, SEEK_END) != 0) {
+    return;
+  }
+  const size_t file_len = ftell(file);
+
+  // Allocate buffer
+  char* buffer = (char*)malloc(file_len + 1);
+  if (!buffer) {
+    return;
+  }
+
+  // Read entire file into buffer
+  if (fseek(file, 0, SEEK_SET) != 0) {
+    free(buffer);
+    return;
+  }
+  size_t nread = fread(buffer, 1, file_len, file);
+  if (nread != file_len) {
+    free(buffer);
+    return;
+  }
+  buffer[file_len] = 0;
+
+  *data = buffer;
+  *len = file_len;
+}
+
+char* platform_getcwd(char* buf, size_t size) {
+  return getcwd(buf, size);
+}
+
+bool platform_is_fullpath(const char *filename) {
+  return !PathIsRelativeA(filename);
+}
+
+bool platform_is_rootpath(const char* path) {
+  // Returns whether this path originates from the root
+  return platform_is_fullpath(path);
+}
+
+bool platform_cmp_path(const char* str1, const char *str2) {
+  // Consider forward and backward slashes identical
+  while (*str1) {
+    if (!((*str1 == *str2) || (*str1 == '/' && *str2 == '\\') || (*str1 == '\\' && *str2 == '/'))) {
+      return false;
+    }
+    str1++;
+    str2++;
+  }
+  return true;
+}
+
+bool platform_wait_process(pid_t pid, int *result) {
+  if (!result) {
+    return false;
+  }
+  
+  *result = -1;
+  if (!SUCCEEDED(_cwait(result, pid, WAIT_CHILD)))
+    return false;
+  return true;
+}
+
+pid_t platform_wait_process_any(pid_t *pids, size_t pids_len, int *result) {
+  if (!result || !pids_len) {
+    return -1;
+  }
+
+  // pids -> handles
+  HANDLE* handles = (HANDLE*)malloc(sizeof(HANDLE) * pids_len);  
+  if (!handles) {
+    return -1;
+  }
+  memset(handles, 0, sizeof(HANDLE) * pids_len);
+
+  // Wait for any process to signal
+  DWORD res = WaitForMultipleObjects(pids_len, handles, FALSE, INFINITE);
+  if (/*res >= WAIT_OBJECT_0 &&*/ res < (WAIT_OBJECT_0 + pids_len)) {
+    DWORD dwResult = 0;
+    GetExitCodeProcess(handles[res - WAIT_OBJECT_0], &dwResult);
+    *result = dwResult;
+    free(handles);
+    return pids[res - WAIT_OBJECT_0];
+  }
+
+  // Failure
+  free(handles);
+  return -1;
+}
+
+int platform_spawnvp(const char* cname, const char* const* argv, const int handle_in, const int handle_out, const int handle_err) {
+    int ret;
+    STARTUPINFO StartupInfo;
+    PROCESS_INFORMATION ProcessInformation;
+    char *cmd;
+    size_t clen = 0;
+
+    // Count number of argv elements by using NULL terminator
+    while(argv[clen] != NULL) {
+      ++clen;
+    }
+    if (clen < 1) {
+      // At least one argument (program name) required
+      return -1;
+    }
+
+    // Join argv into full command line string
+    {
+      // Calculate total string length
+      size_t total_length = 0;
+      for (size_t i = 0; i < clen; ++i) {
+        total_length += strlen(argv[i]);
+      }
+
+      // Add spaces (except last) and terminator
+      total_length += (clen - 1) + 1;
+
+      // Allocate
+      cmd = (char*)malloc(total_length * sizeof(char));
+      if (cmd == NULL) {
+        return -1;
+      }
+      cmd[0] = 0;
+
+      // Concatenate
+      for (size_t i = 0; i < clen; ++i) {
+        strcat(cmd, argv[i]);
+        if (i < (clen - 1)) {
+          strcat(cmd, " ");
+        }
+      }
+    }
+
+    memset(&StartupInfo, 0, sizeof(StartupInfo));
+    StartupInfo.cb = sizeof(StartupInfo);
+    StartupInfo.wShowWindow = FALSE;
+    StartupInfo.hStdInput = handle_in != -1 ? (HANDLE)_get_osfhandle(handle_in) : GetStdHandle(STD_INPUT_HANDLE);
+    StartupInfo.hStdOutput  = handle_out != -1 ? (HANDLE)_get_osfhandle(handle_out) : GetStdHandle(STD_OUTPUT_HANDLE);
+    StartupInfo.hStdError = handle_err != -1 ? (HANDLE)_get_osfhandle(handle_err) : GetStdHandle(STD_ERROR_HANDLE);
+    if (!(StartupInfo.hStdInput == INVALID_HANDLE_VALUE &&
+        StartupInfo.hStdOutput == INVALID_HANDLE_VALUE &&
+        StartupInfo.hStdError == INVALID_HANDLE_VALUE))
+    {
+        StartupInfo.dwFlags |= STARTF_USESTDHANDLES;
+    }
+    if (!CreateProcess(cname,   /* search PATH to find executable */
+                       cmd,   /* executable, and its arguments */
+                       NULL,    /* process attributes */
+                       NULL,    /* thread attributes */
+                       TRUE,    /* inherit handles */
+                       CREATE_NO_WINDOW,    /* creation flags */
+                       NULL, /* inherit environment */
+                       NULL,   /* inherit cwd */
+                       &StartupInfo,
+                       &ProcessInformation))
+    {
+      return -1;
+    }
+    ret = (int)ProcessInformation.dwProcessId;
+    CloseHandle(ProcessInformation.hThread);
+    free(cmd);
+    return ret;
+}
+
+void platform_kill(int pid) {
+  HANDLE handle = OpenProcess(PROCESS_TERMINATE, FALSE, (DWORD)pid);
+  if (handle == NULL) {
+    // Failure
+    return;
+  }
+  TerminateProcess(handle, 1);
+}
+
+#else
+//////////////////////////////////////////////////////////////////////////////
+// Platform specific implementations
+//////////////////////////////////////////////////////////////////////////////
+//
+// POSIX
+//
+#include <unistd.h>
+
+// Creates a temporary file with a given extension and returns the path
+FILE* platform_mktempfile2(const char* ext, char** path, const char* mode) {
+  if (!path) {
+    return NULL;
+  }
+
+  // Construct full path template
+  const size_t MAX_PATH = 255;
+  char fp[MAX_PATH + 1];
+  snprintf(fp, (sizeof(char) * MAX_PATH), "/tmp/xcc-XXXXXX%s", ext ? ext : "");
+  fp[MAX_PATH] = 0;
+
+  // Create temporary file
+  int fd = mkstemps(fp, ext ? strlen(ext) : 0);
+  *path = strdup(fp);
+  return fdopen(fd, mode);
+}
+
+// Creates a temporary file, opens it in write-binary mode
+FILE* platform_mktempfile(void) {
+  return tmpfile();
+}
+
+// Flushes the temporary file and ensures the data pointer contains a pointer to the contents of the buffer if necessary
+void flush_memstream(FILE* file, char** data, size_t* len) {
+  (void)file;
+  (void)data;
+  (void)len;
+  // This function is a nop because on POSIX, the memstream does this on open
+}
+
+char* platform_getcwd(char* buf, size_t size) {
+  return getcwd(buf, size);
+}
+
+bool platform_is_fullpath(const char* filename) {
+  // Path without any .. operators
+  if (*filename != '/')
+    return false;
+  for (const char *p = filename;;) {
+    p = strstr(p, "/..");
+    if (p == NULL)
+      return true;
+    if (p[3] == '/' || p[3] == '\0')
+      return false;
+    p += 3;
+  }
+}
+
+bool platform_is_rootpath(const char* path) {
+  // Returns whether this path originates from the root
+  return *path == '/';
+}
+
+bool platform_cmp_path(const char* a, const char* b) {
+  return strcmp(a, b) == 0;
+}
+
+// Unsupported functions for WASM targets
+#ifndef __WASM
+#include <signal.h>
+#include <sys/wait.h>
+
+bool platform_wait_process(pid_t pid, int* result) {
+  if (waitpid(pid, result, 0) < 0) {
+    return false;
+  }
+  return true;
+}
+
+pid_t platform_wait_process_any(pid_t* pids, size_t pids_len, int* result) {
+  (void)pids;
+  (void)pids_len;
+
+  // Assumes all processes have been forked, so waitpid will do
+  *result = -1;
+  return waitpid(0, result, 0);
+}
+
+void platform_kill(int pid) {
+  kill(pid, SIGKILL);
+}
+
+#endif
+
+#endif

--- a/src/util/platform.h
+++ b/src/util/platform.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <sys/types.h>
+
+//////////////////////////////////////////////////////////////////////////////
+// Platform independent implementations
+//////////////////////////////////////////////////////////////////////////////
+
+// Modifies a path in-place to changes slashes to forward slashes only,
+// so it doesn't generate escape sequences in the preprocessor include generator
+char* platform_pathslashes(char* buf);
+
+// Creates a temporary file with a given extension, opens it in write-binary mode, returns the path
+FILE* platform_mktempfile2(const char* ext, char** path, const char* mode);
+
+// Creates a temporary file, opens it in write-binary mode
+FILE* platform_mktempfile(void);
+
+// Flushes the temporary file and ensures the data pointer contains a pointer to the contents of the buffer if necessary
+void flush_memstream(FILE* file, char** data, size_t* len);
+
+char* platform_getcwd(char* buf, size_t size);
+bool platform_is_fullpath(const char* path);
+bool platform_is_rootpath(const char* path);
+bool platform_cmp_path(const char* a, const char* b);
+
+bool platform_wait_process(pid_t pid, int* result);
+pid_t platform_wait_process_any(pid_t *pids, size_t pids_len, int* result);
+
+void platform_kill(int pid);
+
+//////////////////////////////////////////////////////////////////////////////
+// Platform specific implementations
+//////////////////////////////////////////////////////////////////////////////
+//
+// Win32
+//
+#ifdef _WIN32
+
+#include <sys/stat.h>
+
+// Replacements
+FILE* fmemopen(void* buf, size_t len, const char* mode);
+FILE* open_memstream(char** data, size_t* len);
+char* strndup(const char* s1, unsigned long long n);
+
+int platform_spawnvp(const char* cname, const char* const* argv, const int handle_in, const int handle_out, const int handle_err);
+
+#endif

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -11,6 +11,11 @@
 #include "../version.h"
 #include "table.h"
 
+#ifdef _WIN32
+// Requires implementation of getline
+#include "getline.h"
+#endif
+
 int isalnum_(int c) {
   return isalnum(c) || c == '_';
 }

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -3,12 +3,15 @@
 #pragma once
 
 #include <stdbool.h>
+#include <stdint.h>
 #include <stddef.h>  // size_t
 #include <stdio.h>  // FILE
 #include <sys/types.h>  // ssize_t
 #include <stdint.h>
 
 #include "../config.h"
+
+#include "platform.h" // platform specifics
 
 #define MIN(a, b)  ((a) < (b) ? (a) : (b))
 #define MAX(a, b)  ((a) > (b) ? (a) : (b))

--- a/src/wcc/gen_wasm.c
+++ b/src/wcc/gen_wasm.c
@@ -1,7 +1,6 @@
 #include "../config.h"
 #include "wcc.h"
 
-#include <alloca.h>
 #include <assert.h>
 #include <limits.h>
 #include <stdio.h>

--- a/src/wcc/wasm_linker.c
+++ b/src/wcc/wasm_linker.c
@@ -1,7 +1,7 @@
 #include "../config.h"
 #include "wasm_linker.h"
 
-#include <ar.h>
+#include "../ar/ar.h"
 #include <assert.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -12,6 +12,7 @@ CFLAGS:=-ansi -std=c11 -Wall -Wextra -Werror \
 	-Wno-empty-body
 CFLAGS+=-I$(CC1_FE_DIR) -I$(UTIL_DIR)
 CFLAGS+=-D_POSIX_C_SOURCE=200809L  # for getline
+CFLAGS+=-D_DEFAULT_SOURCE # mkstemps
 
 PREFIX:=
 XCC:=../$(PREFIX)xcc
@@ -109,8 +110,8 @@ test-link:
 endif
 
 INITIALIZER_SRCS:=initializer_test.c $(CC1_FE_DIR)/parser.c $(CC1_FE_DIR)/parser_expr.c $(CC1_FE_DIR)/lexer.c \
-	$(CC1_FE_DIR)/initializer.c $(CC1_FE_DIR)/fe_misc.c $(CC1_FE_DIR)/var.c $(CC1_FE_DIR)/type.c $(CC1_FE_DIR)/ast.c $(UTIL_DIR)/util.c $(UTIL_DIR)/table.c \
-	$(DEBUG_DIR)/dump_expr.c
+	$(CC1_FE_DIR)/initializer.c $(CC1_FE_DIR)/fe_misc.c $(CC1_FE_DIR)/var.c $(CC1_FE_DIR)/type.c $(CC1_FE_DIR)/ast.c $(UTIL_DIR)/util.c \
+	$(UTIL_DIR)/platform.c $(UTIL_DIR)/table.c $(DEBUG_DIR)/dump_expr.c
 initializer_test:	$(INITIALIZER_SRCS)
 	$(CC) -o$@ -DNO_MAIN_DUMP_EXPR $(CFLAGS) $^
 
@@ -118,13 +119,13 @@ TABLE_SRCS:=table_test.c $(UTIL_DIR)/table.c
 table_test:	$(TABLE_SRCS)
 	$(CC) -o$@ $(CFLAGS) $^
 
-UTIL_SRCS:=util_test.c $(UTIL_DIR)/util.c $(UTIL_DIR)/table.c
+UTIL_SRCS:=util_test.c $(UTIL_DIR)/util.c $(UTIL_DIR)/platform.c $(UTIL_DIR)/table.c
 util_test:	$(UTIL_SRCS)
 	$(CC) -o$@ $(CFLAGS) $^
 
 PARSER_SRCS:=parser_test.c $(CC1_FE_DIR)/parser_expr.c $(CC1_FE_DIR)/lexer.c $(CC1_FE_DIR)/parser.c \
 	$(CC1_FE_DIR)/initializer.c $(CC1_FE_DIR)/fe_misc.c $(CC1_FE_DIR)/type.c $(CC1_FE_DIR)/ast.c $(CC1_FE_DIR)/var.c \
-	$(UTIL_DIR)/util.c $(UTIL_DIR)/table.c
+	$(UTIL_DIR)/util.c $(UTIL_DIR)/platform.c $(UTIL_DIR)/table.c
 parser_test:	$(PARSER_SRCS)
 	$(CC) -o$@ $(CFLAGS) $^
 
@@ -138,7 +139,7 @@ dvaltest:	$(FVAL_SRCS) flotest.inc # $(XCC)
 fvaltest:	$(FVAL_SRCS) flotest.inc # $(XCC)
 	$(XCC) -o$@ -Werror -DUSE_SINGLE $(FVAL_SRCS)
 
-TYPE_SRCS:=print_type_test.c $(CC1_FE_DIR)/type.c $(UTIL_DIR)/util.c $(UTIL_DIR)/table.c
+TYPE_SRCS:=print_type_test.c $(CC1_FE_DIR)/type.c $(UTIL_DIR)/util.c $(UTIL_DIR)/platform.c $(UTIL_DIR)/table.c
 print_type_test:	$(TYPE_SRCS)
 	$(CC) -o $@ $(CFLAGS) $^
 


### PR DESCRIPTION
Implements #1.

Requires MinGW64 MSYS as toolchain.

Notes:
* Relies on #158 (`long` types are 32-bit, not 64-bit on Win32).
* Adds two new vendor files from NetBSD (with permissive BSD license): `ar.h` and `getline.h`.
* Moves most platform specifics into `platform.c` and `platform.h`.

Passes `test-wcc` and `test-wcc-gen2` tests on Win32.