### PR TITLE
feat: Allow exporting WASM function using __attribute((export))

### DIFF
--- a/src/util/platform.c
+++ b/src/util/platform.c
@@ -11,8 +11,11 @@
 // Modifies a path in-place to changes slashes to forward slashes only,
 // so it doesn't generate escape sequences in the preprocessor include generator
 char* platform_pathslashes(char* buf) {
+  if (!buf) {
+    return NULL;
+  }
   size_t i;
-  for(i = 0; i < strlen(buf); ++i) {
+  for (i = 0; i < strlen(buf); ++i) {
     if (buf[i] == '\\') {
       buf[i] = '/';
     }

--- a/src/wcc/emit_wasm.c
+++ b/src/wcc/emit_wasm.c
@@ -565,6 +565,9 @@ static void emit_linking_section(EmitWasm *ew) {
         flags |= WASM_SYM_UNDEFINED;
       if (info->varinfo->storage & VS_STATIC)
         flags |= WASM_SYM_BINDING_LOCAL | WASM_SYM_VISIBILITY_HIDDEN;
+      if (info->exported) {
+        flags |= WASM_SYM_EXPORTED;
+      }
 
       data_push(&linking_section, SIK_SYMTAB_FUNCTION);  // kind
       data_uleb128(&linking_section, -1, flags);

--- a/src/wcc/traverse.c
+++ b/src/wcc/traverse.c
@@ -117,6 +117,10 @@ static FuncInfo *register_func_info(const Name *funcname, Function *func, VarInf
       else
         info->func_name = alloc_name(token->str.buf, token->str.buf + token->str.len - 1, false);
     }
+    // Export
+    if (table_try_get(attributes, alloc_name("export", NULL, false), (void**)&params)) {
+      info->exported = true;
+    }
   }
 
   return info;

--- a/src/wcc/wasm_linker.c
+++ b/src/wcc/wasm_linker.c
@@ -714,6 +714,17 @@ static bool resolve_symbols(WasmLinker *linker) {
         sym->combined_index = unresolved_func_count++;
         break;
       }
+      // Check if unresolved functions are allowed
+      if (linker->allow_unresolved) {
+        if (verbose) {
+          if (sym->module_name != NULL)
+            fprintf(stderr, "Allowed unresolved function: %.*s.%.*s\n", NAMES(sym->module_name), NAMES(name));
+          else
+            fprintf(stderr, "Allowed unresolved function: %.*s\n", NAMES(name));
+        }
+        sym->combined_index = unresolved_func_count++;
+        break;
+      }
 
       if (sym->module_name != NULL)
         fprintf(stderr, "Unresolved: %.*s.%.*s\n", NAMES(sym->module_name), NAMES(name));
@@ -1427,6 +1438,7 @@ void linker_init(WasmLinker *linker) {
   linker->sp_name = alloc_name(SP_NAME, NULL, false);
   linker->curbrk_name = alloc_name(BREAK_ADDRESS_NAME, NULL, false);
 
+  linker->allow_unresolved = false;
   linker->exported_functions = new_vector();
 }
 

--- a/src/wcc/wasm_linker.h
+++ b/src/wcc/wasm_linker.h
@@ -23,6 +23,9 @@ typedef struct {
 
   FILE *ofp;
 
+  // Allow unresolved exports
+  bool allow_unresolved;
+
   // Exported functions
   Vector *exported_functions;
 } WasmLinker;

--- a/src/wcc/wasm_linker.h
+++ b/src/wcc/wasm_linker.h
@@ -22,6 +22,9 @@ typedef struct {
   const Name *curbrk_name;
 
   FILE *ofp;
+
+  // Exported functions
+  Vector *exported_functions;
 } WasmLinker;
 
 void linker_init(WasmLinker *linker);

--- a/src/wcc/wcc.c
+++ b/src/wcc/wcc.c
@@ -289,6 +289,8 @@ static void parse_options(int argc, char *argv[], Options *opts) {
       show_version(NULL);
       exit(0);
     case 'o':
+      // Ensure forward slashes for C compatibility
+      platform_pathslashes(optarg);
       opts->ofn = optarg;
       break;
     case 'c':
@@ -308,18 +310,26 @@ static void parse_options(int argc, char *argv[], Options *opts) {
       }
       break;
     case 'I':
+      // Ensure forward slashes for C compatibility
+      platform_pathslashes(optarg);
       add_inc_path(INC_NORMAL, optarg);
       break;
     case OPT_ISYSTEM:
+      // Ensure forward slashes for C compatibility
+      platform_pathslashes(optarg);
       add_inc_path(INC_SYSTEM, optarg);
       break;
     case OPT_IDIRAFTER:
+      // Ensure forward slashes for C compatibility
+      platform_pathslashes(optarg);
       add_inc_path(INC_AFTER, optarg);
       break;
     case 'D':
       define_macro(optarg);
       break;
     case 'L':
+      // Ensure forward slashes for C compatibility
+      platform_pathslashes(optarg);
       vec_push(opts->lib_paths, optarg);
       break;
     case 'x':
@@ -456,6 +466,10 @@ static int do_compile(Options *opts) {
 
   for (int i = 0; i < opts->sources->len; ++i) {
     char *src = opts->sources->data[i];
+
+    // Ensure forward slashes for C compatibility
+    platform_pathslashes(src);
+
     const char *outfn = opts->ofn;
     if (src != NULL) {
       if (*src == '\0')

--- a/src/wcc/wcc.h
+++ b/src/wcc/wcc.h
@@ -42,6 +42,7 @@ typedef struct {
   int flag;
   uint32_t type_index;
   uint32_t indirect_index;
+  bool exported; // indicates a WASM exported function
 } FuncInfo;
 
 #define GVF_EXPORT      (1 << 0)


### PR DESCRIPTION
Adds the ability to export functions to WASM from the C code, apart from just the entry point, by using `__attribute((export))`.

Example code:
```c
__attribute__((export)) bool test() {
  return true;
}
```

Adds these command line arguments:
* `--no-entry-point` to avoid forcing an entry point. Allow no entry points.
* `--allow-unresolved` to allow for imports of dynamically exported functions from the WASM host.